### PR TITLE
Avoid crashes for files with position information following the timestamp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srtlib"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Konstantinos Gavalas <contact@gavalas.dev>"]
 edition = "2018"
 description = "A simple library for handling .srt subtitle files"


### PR DESCRIPTION
Hi,
First of all, thank you for this library, I've used it to create a small tool to extract text from subtitles and it worked great. However, I've had a few crashes on files with position information following the timestamp. Here's a minimal example:
```
1
00:00:07,001 --> 00:00:09,015 position:50,00%,middle align:middle size:80,00% line:84,67%
This is a subtitle text
```
I've fixed this by modifying a bit the parsing code of the timestamp line of `Subtitle.parse` to be able to handle that, and added a test case. I've also edited the documentation to reflect the changes.